### PR TITLE
Remove the rotateme class from dropdown chevron

### DIFF
--- a/components/navbar.vue
+++ b/components/navbar.vue
@@ -84,6 +84,10 @@ export default {
       Array.from(drop_menus).forEach(function(e){
         e.classList.remove("display");
       });
+      var chevrons = document.getElementsByClassName("chevron-down");
+      Array.from(chevrons).forEach(function(e){
+        e.classList.remove("rotateme");
+      });
     },
     display_menu(delay) {
       var body = document.getElementsByTagName("body")[0];


### PR DESCRIPTION
Remove the rotateme class from dropdown chevron when dropdown is closed, fixes #130